### PR TITLE
check for def of EASEDEF

### DIFF
--- a/src/reasings.h
+++ b/src/reasings.h
@@ -84,10 +84,12 @@
 
 #define REASINGS_STATIC_INLINE     // NOTE: By default, compile functions as static inline
 
+#ifndef EASEDEF
 #if defined(REASINGS_STATIC_INLINE)
     #define EASEDEF static inline
 #else
     #define EASEDEF extern
+#endif
 #endif
 
 #include <math.h>       // Required for: sinf(), cosf(), sqrtf(), powf()


### PR DESCRIPTION
This would allow me to define `EASEDEF` before loading the header (helps with exposing to wasm.) Like this:

```c
#define EASEDEF EMSCRIPTEN_KEEPALIVE
#include "reasings.h"
```